### PR TITLE
set mortar version to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "react-select": "^3.1.0"
   },
   "devDependencies": {
-    "@opendoor/mortar": "*",
+    "@opendoor/mortar": "latest",
     "@twilio/flex-ui": "^1.19.0",
     "babel-polyfill": "^6.26.0",
     "enzyme": "^3.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1888,10 +1888,10 @@
   resolved "https://registry.yarnpkg.com/@oclif/screen/-/screen-1.0.4.tgz#b740f68609dfae8aa71c3a6cab15d816407ba493"
   integrity sha512-60CHpq+eqnTxLZQ4PGHYNwUX572hgpMHGPtTWMjdTMsAvlm69lZV/4ly6O3sAYkomo4NggGcomrDpBe34rxUqw==
 
-"@opendoor/mortar@*":
-  version "0.0.0-local-fc65f85dad6f30b085faa0b604670432ec2d1183"
-  resolved "https://registry.yarnpkg.com/@opendoor/mortar/-/mortar-0.0.0-local-fc65f85dad6f30b085faa0b604670432ec2d1183.tgz#86a1018d94192923ef24e79c4183c8afc806f453"
-  integrity sha512-YCm1wtquLRLBMH21Oj9rSm70gMP/7co6kXqNwCItsCYuz4LVeZkcL6o3QAAlzy+W/JGv/mPTeGN7ADpL8F6BmA==
+"@opendoor/mortar@latest":
+  version "0.0.0-local-c285b43f475e8a066d5c7c9453dd87010b2e47d5"
+  resolved "https://registry.yarnpkg.com/@opendoor/mortar/-/mortar-0.0.0-local-c285b43f475e8a066d5c7c9453dd87010b2e47d5.tgz#bf4243f71e213675adbc3b5b480ac0e38ffa5b13"
+  integrity sha512-T2Rr8eLtBcIosmXpqmOntGlQIjpcy+5gsAAujPkl//Xka4y76nDdFu/oX2ICak/HPh4rwXpOr8Ur6HDiof0Aag==
   dependencies:
     "@babel/cli" "7.10.4"
     "@babel/core" "7.10.4"


### PR DESCRIPTION
Signed-off-by: Maggie Moreno <maggie.moreno@opendoor.com>

Without our handy helpful scripts in code/js, setting the `@opendoor/mortar` version at `*` causes `yarn install` to throw an error.

```
+ yarn install
yarn install v1.21.1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               
[1/4] Resolving packages...                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        
warning Lockfile has incorrect entry for "@opendoor/mortar@*". Ignoring it.                                                                                                                                                                                                                                                                                                                                                                                                                                        
error An unexpected error occurred: "https://registry.yarnpkg.com/@opendoor%2fmortar: Not found".                                                                                                                                                                                                                                                                                                                                                                                                                  
info If you think this is a bug, please open a bug report with the information provided in "/tmp/build/cbb1c7ed/plugin-dialpad/yarn-error.log".                                                                                                                                                                                                                                                                                                                                                                    
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.                                                                                                                                                                                                                                                                                                                                                                                                                           
```

Let's just set the version to `latest`. I may regret this... But since it is only used in the deploy pipeline, it is unlikely to break the live plugin.