### PR TITLE
don't run bootstrap after install, don't check start

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "upload_assets": "yarn mortar pkg:upload_assets -b odfil.es -p twilio-flex-plugins/$STAGE/$RELEASE_SHA",
     "bootstrap": "flex-plugin check-start",
-    "prebuild": "rimraf build && yarn bootstrap",
+    "prebuild": "rimraf builds",
     "build": "./node_modules/.bin/env-cmd -f .env.production flex-plugin build",
     "clear": "flex-plugin clear",
     "predeploy": "yarn build",
@@ -14,7 +14,6 @@
     "info": "flex-plugin info",
     "list": "flex-plugin list",
     "remove": "flex-plugin remove",
-    "prestart": "yarn bootstrap",
     "start": "./node_modules/.bin/env-cmd -f .env.development flex-plugin start",
     "test": "jest --passWithNoTests"
   },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "deploy": "flex-plugin deploy",
     "eject": "flex-plugin eject",
     "info": "flex-plugin info",
-    "postinstall": "yarn bootstrap",
     "list": "flex-plugin list",
     "remove": "flex-plugin remove",
     "prestart": "yarn bootstrap",


### PR DESCRIPTION
Signed-off-by: Maggie Moreno <maggie.moreno@opendoor.com>

This is causing at least one class of errors in the deploy pipeline.

https://concourse.managed.services.opendoor.com/teams/engineering/pipelines/twilio-flex-plugins/jobs/test-and-upload-plugin-dialpad/builds/10

```
+ cd plugin-dialpad/
+ echo //registry.npmjs.org/:_authToken=0793e438-be37-4a8d-b92e-a76dc4e09dbe
+ yarn install
yarn install v1.21.1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               
[1/4] Resolving packages...                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        
[2/4] Fetching packages...                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         
warning sha.js@2.4.11: Invalid bin entry for "sha.js" (in "sha.js").                                                                                                                                                                                                                                                                                                                                                                                                                                               
info fsevents@2.1.3: The platform "linux" is incompatible with this module.                                                                                                                                                                                                                                                                                                                                                                                                                                        
info "fsevents@2.1.3" is an optional dependency and failed compatibility check. Excluding it from installation.                                                                                                                                                                                                                                                                                                                                                                                                    
info fsevents@1.2.13: The platform "linux" is incompatible with this module.                                                                                                                                                                                                                                                                                                                                                                                                                                       
.
.
.
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:248:12)
gyp ERR! System Linux 4.9.0-11-amd64
gyp ERR! command \"/usr/local/bin/node\" \"/usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js\" \"rebuild\"
gyp ERR! cwd /tmp/build/cbb1c7ed/plugin-dialpad/node_modules/keytar
warning Your current version of Yarn is out of date. The latest version is "1.22.5", while you're on "1.21.1".                                                                                                                                                                                                                                                                                                                                                                                                     
info To upgrade, run the following command:                                                                                                                                                                                                                                                                                                                                                                                                                                                                        
$ curl --compressed -o- -L https://yarnpkg.com/install.sh | bash                                                                                                                                                                                                                                                                                                                                                                                                                                                   
$ yarn bootstrap                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   
yarn run v1.21.1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   
$ flex-plugin check-start                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          

There might be a problem with your project file hierarchy.

The flex-plugin-scripts requires the following file to be present:

	 public/appConfig.js

Check your public/ directory for appConfig.example.js, copy it to appConfig.js, and modify your Account Sid and Service URL.

error Command failed with exit code 1.                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.                                                                                                                                                                                                                                                                                                                                                                                                                               
error Command failed with exit code 1.                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.                  
```